### PR TITLE
Implemented auto-update functionality

### DIFF
--- a/Dockerfile-publish-linux
+++ b/Dockerfile-publish-linux
@@ -1,0 +1,19 @@
+FROM electronuserland/builder:10
+
+# Create app directory
+RUN mkdir -p /opt/blockdx-ui/dist-native
+WORKDIR /opt/blockdx-ui/
+VOLUME /opt/blockdx-ui/dist-native
+
+# Install app dependencies
+COPY package.json /opt/blockdx-ui/
+RUN npm install --no-audit
+
+# Bundle app source
+COPY . /opt/blockdx-ui/
+
+ARG GIT_BRANCH=""
+RUN echo GIT_BRANCH=$GIT_BRANCH > /opt/blockdx-ui/electron-builder.env
+
+ENTRYPOINT ["npm"]
+CMD ["run", "publish-native-linux"]

--- a/Dockerfile-publish-win
+++ b/Dockerfile-publish-win
@@ -1,0 +1,19 @@
+FROM electronuserland/builder:wine
+
+# Create app directory
+RUN mkdir -p /opt/blockdx-ui/dist-native
+WORKDIR /opt/blockdx-ui/
+VOLUME /opt/blockdx-ui/dist-native
+
+# Install app dependencies
+COPY package.json /opt/blockdx-ui/
+RUN npm install --no-audit
+
+# Bundle app source
+COPY . /opt/blockdx-ui/
+
+ARG GIT_BRANCH=""
+RUN echo GIT_BRANCH=$GIT_BRANCH > /opt/blockdx-ui/electron-builder.env
+
+ENTRYPOINT ["npm"]
+CMD ["run", "publish-native-win"]

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "build-native": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --production && cd .. && electron-builder --dir",
-    "build-native-all": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir -mwl",
-    "build-native-win": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --win nsis zip --publish never",
-    "build-native-mac": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --mac zip --publish never",
-    "build-native-linux": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --linux appImage deb tar.gz --publish never",
+    "build-native-win": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --ia32 --config.artifactName=\"${name}-${env.GIT_BRANCH}-${os}-${arch}.${ext}\" --win nsis zip --publish never",
+    "build-native-mac": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --config.artifactName=\"${name}-${env.GIT_BRANCH}-${os}.${ext}\" --mac zip --publish never",
+    "build-native-linux": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --dir --x64 --config.artifactName=\"${name}-${env.GIT_BRANCH}-${os}.${ext}\" --linux appImage deb tar.gz --publish never",
+    "publish-native-win": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --win --publish always",
+    "publish-native-mac": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --publish always",
+    "publish-native-linux": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --no-audit --production && cd .. && electron-builder --publish always",
     "pack-native": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --production && cd .. && electron-builder",
     "publish-native": "npm run build && node ./native-build-scripts/01-copy-files.js && cd temp && npm install --production && cd .. && electron-builder --publish always",
     "generate-docs": "jsdoc src-back/service-node-interface.js -d docs",
@@ -58,7 +60,7 @@
     "electron-context-menu": "^0.9.1",
     "electron-is-dev": "^0.3.0",
     "electron-serve": "^0.1.0",
-    "electron-updater": "^2.21.4",
+    "electron-updater": "^4.0.5",
     "font-awesome": "^4.7.0",
     "fs-extra-promise": "^1.0.1",
     "hammerjs": "^2.0.8",
@@ -88,8 +90,8 @@
     "@types/jquery": "^3.2.16",
     "@types/node": "^8.0.57",
     "codelyzer": "^4.0.2",
-    "electron": "^1.8.4",
-    "electron-builder": "^19.56.0",
+    "electron": "^3.0.11",
+    "electron-builder": "^20.38.3",
     "electron-publisher-s3": "^20.8.1",
     "eslint": "^4.17.0",
     "jasmine-core": "^2.8.0",
@@ -112,26 +114,32 @@
   },
   "main": "index.js",
   "build": {
-    "electronVersion": "1.8.4",
+    "electronVersion": "3.0.11",
     "appId": "co.blocknet.blockdx",
     "productName": "BLOCK DX",
-    "artifactName": "${name}-${env.GIT_BRANCH}-${os}.${ext}",
+    "artifactName": "${name}-${version}-${os}.${ext}",
     "copyright": "Copyright © 2018 Blocknet",
     "directories": {
       "app": "temp",
       "output": "dist-native"
     },
     "win": {
+      "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
+      "verifyUpdateCodeSignature": false,
       "target": [
         {
-          "target": "nsis",
+          "target": "zip",
           "arch": [
             "x64",
             "ia32"
           ]
         },
         {
-          "target": "zip"
+          "target": "nsis",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
         }
       ],
       "icon": "./src/assets/favicon_block.ico",
@@ -142,6 +150,7 @@
     },
     "mac": {
       "target": [
+        "dmg",
         "zip"
       ],
       "category": "public.app-category.utilities",
@@ -154,8 +163,8 @@
     "linux": {
       "target": [
         "appImage",
-        "deb",
-        "tar.gz"
+        "tar.gz",
+        "deb"
       ],
       "icon": "./src/assets/linux_icons/",
       "synopsis": "Copyright © 2018 Blocknet",

--- a/src/app/nav-bar/nav-bar.component.html
+++ b/src/app/nav-bar/nav-bar.component.html
@@ -16,6 +16,7 @@
         <li><a href="#" (click)="openGeneralSettings($event)">General Settings</a></li>
         <li><a href="#" (click)="openConfigurationWizard($event)">Basic Setup</a></li>
         <li><a href="#" (click)="openSettings($event)">RPC Settings</a></li>
+        <li><a href="#" (click)="checkForUpdates($event)">Check for Updates</a></li>
       </ul>
       <ul>
         <li>Information</li>
@@ -34,6 +35,10 @@
         <li><a href="#" (click)="openLink($event, 'reddit')">Reddit</a></li>
         <li><a href="#" (click)="openLink($event, 'twitter')">Twitter</a></li>
         <li><a href="#" (click)="openLink($event, 'discord')">Discord</a></li>
+      </ul>
+      <ul>
+        <li class="app-version"></li>
+        <li class="app-version">v {{appVersion}}</li>
       </ul>
     </div>
     <a (click)="toggleNav()" class="navbar-toggler">

--- a/src/app/nav-bar/nav-bar.component.scss
+++ b/src/app/nav-bar/nav-bar.component.scss
@@ -222,3 +222,8 @@ app-pair-selector {
     @extend .type3;
   }
 }
+
+.app-version {
+  color: #587292;
+  font-size: 12px;
+}

--- a/src/app/nav-bar/nav-bar.component.ts
+++ b/src/app/nav-bar/nav-bar.component.ts
@@ -18,12 +18,18 @@ export class NavBarComponent implements OnInit {
   public navCollapsed: boolean;
   public pairSelectorActiveState: boolean;
 
+  public appName: string;
+  public appVersion: string;
+
   constructor(
     private appService: AppService,
     private currentpriceService: CurrentpriceService,
     private numberFormatPipe: NumberFormatPipe,
     private zone: NgZone
-  ) { }
+  ) {
+    this.appName = window.electron.ipcRenderer.sendSync('getAppName');
+    this.appVersion = window.electron.ipcRenderer.sendSync('getAppVersion');
+  }
 
   ngOnInit() {
 
@@ -62,6 +68,29 @@ export class NavBarComponent implements OnInit {
     e.preventDefault();
     window.electron.ipcRenderer.send('openConfigurationWizard');
     this.toggleNav();
+  }
+
+  checkForUpdates(e) {
+    e.preventDefault();
+    if(window.electron.ipcRenderer.sendSync('updateError')) {
+      const { openExternal } = window.electron.remote.shell;
+      openExternal('https://github.com/BlocknetDX/blockdx-ui/releases/latest');
+    } else {
+      const status = window.electron.ipcRenderer.sendSync('checkForUpdates');
+      switch(status) {
+        case 'available':
+          break;
+        case 'downloading':
+          alert('An update is currently being downloaded. A prompt will appear when complete.');
+          break;
+        case 'downloaded':
+          // alert('Update has been downloaded and will be installed once you restart the application.');
+          break;
+        default:
+          alert('There are no Block DX updates available at this time.');
+      }
+      this.toggleNav();
+    }
   }
 
   openNotices(e) {

--- a/src/update-available.html
+++ b/src/update-available.html
@@ -9,6 +9,7 @@
 
   <link rel="shortcut icon" href="assets/favicon_block.png"  />
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700|Roboto+Mono:300,400,700" rel="stylesheet">
+  <link href="./assets/vendor/css/fontawesome-all.min.css" rel="stylesheet">
   <!--<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">-->
 
   <style>
@@ -32,13 +33,13 @@
     .container {
       padding: 0 20px;
     }
-    .input-group {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: nowrap;
-      justify-content: flex-start;
-      margin-bottom: 15px;
-    }
+    /*.input-group {*/
+      /*display: flex;*/
+      /*flex-direction: row;*/
+      /*flex-wrap: nowrap;*/
+      /*justify-content: flex-start;*/
+      /*margin-bottom: 15px;*/
+    /*}*/
     .input-group label {
       width: 35%;
       background-color: #213d54;
@@ -60,14 +61,17 @@
       outline-width: 0;
     }
     .input-group input:focus {
-      outline-width: 0px;
+      outline-width: 0;
       border-width: 1px;
       border-color: #4b6275;
       border-style: solid;
     }
     .label {
       color: #fff;
-      padding: 30px 0;
+      padding-top: 30px;
+      padding-bottom: 0;
+      padding-left: 0;
+      padding-right: 0;
       font-weight: 300;
       font-size: 14px;
       min-height: 16px;
@@ -117,6 +121,21 @@
       justify-content: flex-start;
       margin-left: -10px;
       margin-right: -10px;
+      padding-top: 15px;
+    }
+    .ask-again-container {
+      padding-top: 20px;
+      color: #888;
+    }
+    .ask-again-container a {
+      opacity: 1;
+      color: #aaa;
+      text-decoration: none;
+    }
+    .ask-again-container a:hover {
+      opacity: .8;
+      color: #aaa;
+      text-decoration: none;
     }
 
   </style>
@@ -125,14 +144,18 @@
 <body>
 
   <div style="width:100%; padding: 20px 0 20px 0; text-align:center;"><img style="max-width:300px;" src="assets/logo_full.svg" alt="Blocknet Logo"></div>
-  <h3>Update Available!</h3>
+  <h3 id="js-header"></h3>
   <form class="container">
 
-    <div class="label"></div>
+    <div id="js-label" class="label"></div>
+
+    <div class="ask-again-container">
+      <a id="js-notAskAgain" style="visibility:hidden;" href="#"><small><i class="far"></i> <span>Do not ask again (you can manually update later from the sidebar menu)</span></small></a>
+    </div>
 
     <div id="js-buttonContainer" class="button-container">
-      <button id="js-cancelBtn" type="button" class="gray-button">CANCEL</button>
-      <button id="js-acceptBtn" type="button">Install Update</button>
+      <button id="js-cancelBtn" type="button" class="gray-button"></button>
+      <button id="js-acceptBtn" type="button"></button>
     </div>
 
   </form>
@@ -153,17 +176,61 @@
 
       const { ipcRenderer } = require('electron');
 
-      const version = ipcRenderer.sendSync('getUpdateVersion');
+      let notAskAgain = false;
+      const notAskAgainIcon = $('#js-notAskAgain').find('i').addClass(notAskAgain ? 'fa-check-square' : 'fa-square');
 
-      $('.label').text(`BLOCK DX version ${version} has been downloaded! Would you like to install it now?`);
+      const version = ipcRenderer.sendSync('getUpdateVersion');
+      const windowType = ipcRenderer.sendSync('getUpdateWindowType'); // updateAvailable|updateDownloaded
+
+      let windowHeader, windowText, confirmButtonText, cancelButtonText;
+
+      switch(windowType) {
+        case 'updateAvailable':
+          windowHeader = 'Update Available!';
+          windowText = `Block DX version ${version} is available! Would you like to download it now?`;
+          confirmButtonText = 'Download Update';
+          cancelButtonText = 'Not Now';
+          break;
+        case 'updateDownloaded':
+          $('#js-notAskAgain').css('display', 'none');
+          windowHeader = `Block DX ${version} Is Ready!`;
+          windowText = `Block DX ${version} is almost ready to use! To complete the update, a restart is required.`;
+          confirmButtonText = 'Restart Now';
+          cancelButtonText = 'Cancel';
+      }
+
+      $('#js-header').text(windowHeader);
+      $('#js-label').text(windowText);
+      $('#js-acceptBtn').text(confirmButtonText);
+      $('#js-cancelBtn').text(cancelButtonText);
+
+      const hideCheckbox = ipcRenderer.sendSync('hideCheckbox');
+      const visibility = hideCheckbox ? 'hidden' : 'visible';
+      $('#js-notAskAgain').css('visibility', visibility);
+
+      $('#js-notAskAgain').on('click', e => {
+        e.preventDefault();
+        const icon = $('#js-notAskAgain').find('i');
+        if(notAskAgain) {
+          icon.addClass('fa-square');
+          icon.removeClass('fa-check-square');
+          notAskAgain = false;
+        } else {
+          icon.addClass('fa-check-square');
+          icon.removeClass('fa-square');
+          notAskAgain = true;
+        }
+      });
 
       $('#js-acceptBtn').on('click', e => {
         e.preventDefault();
+        if(windowType === 'updateAvailable') alert('The update is currently being downloaded. A prompt will appear when complete.');
         ipcRenderer.send('accept');
       });
       $('#js-cancelBtn').on('click', e => {
         e.preventDefault();
-        ipcRenderer.send('cancel');
+        const icon = $('#js-notAskAgain').find('i');
+        ipcRenderer.send('cancel', notAskAgain);
       });
 
     });


### PR DESCRIPTION
Removed window menu from update available window

Turned off auto-install of updates after download

Put slight delay on check for updates so the main window has adequate time to load

Added update check when automation window opened

Save meta backup on Mac before app update applied

Removed unnecessary file removal.

Removed update check from TOS window

Added 'Do not ask again' checkbox to update available window

Added check for updates to menu

Fixed update events to mitigate unexpected multiple firing of events

Updated the update available window

Updated updating text and fixed bugs

Updated artifact names

Added platform targets

Updated electron-builder and electron-updater versions

Check for updates link to releases for non-updatable builds

Added getManifest function back in

Updated electron-updater version

Updated build configuration

Fixed bug in update-available.html and updated build configuration

Added Dockerfiles for publishing Windows and Linux builds